### PR TITLE
ci: land governance execution trio

### DIFF
--- a/.github/workflows/governance-exec-mvp.yml
+++ b/.github/workflows/governance-exec-mvp.yml
@@ -1,0 +1,163 @@
+name: governance-exec-mvp
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled, ready_for_review]
+  issues:
+    types: [opened, edited, labeled, unlabeled, reopened, assigned, unassigned]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  issue-routing:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Route issue
+        env:
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+          ISSUE_ASSIGNEES: ${{ join(github.event.issue.assignees.*.login, ',') }}
+          GITHUB_OUTPUT_JSON: issue_router_result.json
+        run: python3 scripts/governance/issue_router.py
+      - name: Comment routing result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          body=$(python3 - <<'PY'
+from pathlib import Path
+print("<!-- governance-routing -->")
+print("## Governance routing")
+print("```json")
+print(Path('issue_router_result.json').read_text())
+print("```")
+PY
+)
+          existing=$(gh api repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments --paginate --jq '.[] | select(.body | contains("<!-- governance-routing -->")) | .id' | head -n 1)
+          if [ -n "$existing" ]; then
+            gh api repos/${{ github.repository }}/issues/comments/$existing -X PATCH -f body="$body"
+          else
+            gh issue comment "$ISSUE_NUMBER" --body "$body"
+          fi
+
+  issue-nudger:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Evaluate assignment nudges
+        env:
+          ITEM_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+          ITEM_ASSIGNEES: ${{ join(github.event.issue.assignees.*.login, ',') }}
+          GITHUB_OUTPUT_JSON: assignment_nudger_result.json
+        run: python3 scripts/governance/assignment_nudger.py
+      - name: Apply nudges
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          python3 - <<'PY'
+import json
+import os
+import subprocess
+from pathlib import Path
+
+issue_number = os.environ['ISSUE_NUMBER']
+data = json.loads(Path('assignment_nudger_result.json').read_text())
+for action in data.get('actions', []):
+    if action.get('type') != 'comment':
+        continue
+    marker = f"<!-- governance-nudge:{action['key']} -->"
+    body = marker + "\n" + action['message']
+    lookup = subprocess.run([
+        'gh', 'api', f"repos/${{ github.repository }}/issues/{issue_number}/comments", '--paginate',
+        '--jq', f'.[] | select(.body | contains("{marker}")) | .id'
+    ], capture_output=True, text=True, check=True)
+    comment_id = lookup.stdout.strip().splitlines()[0] if lookup.stdout.strip() else ''
+    if comment_id:
+        subprocess.run(['gh', 'api', f"repos/${{ github.repository }}/issues/comments/{comment_id}", '-X', 'PATCH', '-f', f'body={body}'], check=True)
+    else:
+        subprocess.run(['gh', 'issue', 'comment', issue_number, '--body', body], check=True)
+PY
+
+  pr-merge-gate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Evaluate merge gate
+        env:
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          PR_ISSUE_REFS: ${{ github.event.pull_request.body }}
+          PR_REVIEW_DECISION: ${{ github.event.pull_request.review_decision }}
+          PR_MERGEABLE: ${{ github.event.pull_request.mergeable_state }}
+          CHECKS_OK: ${{ !contains(github.event.pull_request.labels.*.name, 'checks/failed') }}
+          GITHUB_OUTPUT_JSON: merge_gate_result.json
+        run: python3 scripts/governance/merge_gate.py
+      - name: Export gate status
+        id: gate
+        run: |
+          gate=$(python3 - <<'PY'
+import json
+from pathlib import Path
+obj = json.loads(Path('merge_gate_result.json').read_text())
+print(obj['gate'])
+PY
+)
+          echo "gate=$gate" >> "$GITHUB_OUTPUT"
+      - name: Comment gate result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          body=$(python3 - <<'PY'
+import json
+from pathlib import Path
+obj = json.loads(Path('merge_gate_result.json').read_text())
+print("<!-- governance-merge-gate -->")
+print(f"## Governance merge gate: {obj['gate']}")
+print("```json")
+print(json.dumps(obj, ensure_ascii=False, indent=2))
+print("```")
+PY
+)
+          existing=$(gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments --paginate --jq '.[] | select(.body | contains("<!-- governance-merge-gate -->")) | .id' | head -n 1)
+          if [ -n "$existing" ]; then
+            gh api repos/${{ github.repository }}/issues/comments/$existing -X PATCH -f body="$body"
+          else
+            gh pr comment "$PR_NUMBER" --body "$body"
+          fi
+      - name: Gate pass marker
+        if: steps.gate.outputs.gate == 'eligible'
+        run: echo 'merge gate says eligible; merge still remains manual'
+
+  release-candidate:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build release candidate input
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          data=$(gh pr list --state merged --base main --limit 20 --json number,title,labels,body,mergedAt | python3 -c "import json,re,sys; prs=json.load(sys.stdin); print(json.dumps([{'number':pr['number'],'title':pr['title'],'labels':[l['name'] for l in pr.get('labels', [])],'issue_refs':re.findall(r'#(\\d+)', pr.get('body') or ''),'mergedAt':pr.get('mergedAt')} for pr in prs], ensure_ascii=False))")
+          echo "MERGED_PRS_JSON=$data" >> "$GITHUB_ENV"
+      - name: Evaluate release candidate
+        env:
+          GITHUB_OUTPUT_JSON: release_candidate_result.json
+        run: python3 scripts/governance/release_candidate.py
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-candidate
+          path: |
+            release_candidate_result.json
+            docs/releases/latest-candidate.json
+            docs/releases/latest-candidate.md

--- a/docs/releases/latest-candidate.json
+++ b/docs/releases/latest-candidate.json
@@ -1,0 +1,9 @@
+{
+  "release_candidate": false,
+  "candidate_count": 0,
+  "items": [],
+  "blockers": [],
+  "commit": "",
+  "run_url": "",
+  "notes_path": "docs/releases/latest-candidate.md"
+}

--- a/docs/releases/latest-candidate.md
+++ b/docs/releases/latest-candidate.md
@@ -1,0 +1,10 @@
+# Release Candidate Snapshot
+
+Generated at: 2026-03-26T00:40:22.158550+00:00
+
+## Candidate PRs
+- none
+
+## Blockers
+- none
+

--- a/scripts/governance/assignment_nudger.py
+++ b/scripts/governance/assignment_nudger.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+
+
+def parse_csv(value):
+    if not value:
+        return []
+    return [item.strip() for item in value.split(',') if item.strip()]
+
+
+def main():
+    labels = parse_csv(os.environ.get('ITEM_LABELS', ''))
+    assignees = parse_csv(os.environ.get('ITEM_ASSIGNEES', ''))
+    status = next((label for label in labels if label.startswith('status/')), 'status/draft')
+
+    actions = []
+    if status == 'status/triaged' and not assignees:
+        actions.append({'type': 'comment', 'key': 'triaged-unassigned', 'message': 'This item is triaged but has no assignee yet. Please assign an owner before it stalls.'})
+    if status == 'status/blocked':
+        actions.append({'type': 'comment', 'key': 'blocked-followup', 'message': 'This item is blocked. Please update the blocker, owner, and next unblock checkpoint.'})
+    if status == 'status/in-review':
+        actions.append({'type': 'comment', 'key': 'review-followup', 'message': 'This item is in review. Please confirm reviewer/decision and either merge or relabel within 24h.'})
+
+    result = {
+        'status': status,
+        'labels': labels,
+        'assignees': assignees,
+        'actions': actions,
+    }
+
+    out = json.dumps(result, ensure_ascii=False, indent=2)
+    Path(os.environ.get('GITHUB_OUTPUT_JSON', 'assignment_nudger_result.json')).write_text(out + '\n', encoding='utf-8')
+    print(out)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/governance/merge_gate.py
+++ b/scripts/governance/merge_gate.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+from pathlib import Path
+
+
+def env(name, default=""):
+    return os.environ.get(name, default)
+
+
+def parse_csv(value):
+    if not value:
+        return []
+    return [item.strip() for item in value.split(',') if item.strip()]
+
+
+def truthy(value):
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def main():
+    labels = parse_csv(env('PR_LABELS'))
+    issue_refs_raw = env('PR_ISSUE_REFS')
+    mergeable = env('PR_MERGEABLE', '').lower()
+    review_decision = env('PR_REVIEW_DECISION', '').upper()
+    required_checks_ok = truthy(env('CHECKS_OK', ''))
+    issue_refs = sorted(set(re.findall(r'#(\d+)', issue_refs_raw or '')))
+
+    checks = {
+        'issue_linked': bool(issue_refs),
+        'status_ready': any(label in labels for label in ('status/in-review', 'status/done')),
+        'blocked': 'status/blocked' in labels,
+        'risk_allowed': 'risk/high' not in labels,
+        'automerge_label': 'automerge' in labels,
+        'required_checks_ok': required_checks_ok,
+        'review_decision': review_decision,
+        'mergeable_state': mergeable,
+    }
+
+    deny_reasons = []
+    hold_reasons = []
+
+    if not checks['issue_linked']:
+        deny_reasons.append('missing linked issue')
+    if checks['blocked']:
+        deny_reasons.append('status/blocked present')
+    if not checks['risk_allowed']:
+        deny_reasons.append('risk/high requires manual override')
+
+    if not checks['status_ready']:
+        hold_reasons.append('missing status/in-review or status/done label')
+    if not checks['automerge_label']:
+        hold_reasons.append('missing automerge label')
+    if not checks['required_checks_ok']:
+        hold_reasons.append('required checks not green')
+    if review_decision not in ('', 'APPROVED'):
+        hold_reasons.append(f'review decision is {review_decision.lower()}')
+    if mergeable and mergeable != 'mergeable':
+        hold_reasons.append(f'pr mergeable state is {mergeable}')
+
+    gate = 'eligible'
+    reasons = []
+    if deny_reasons:
+        gate = 'deny'
+        reasons = deny_reasons + hold_reasons
+    elif hold_reasons:
+        gate = 'hold'
+        reasons = hold_reasons
+
+    result = {
+        'gate': gate,
+        'mergeable': gate == 'eligible',
+        'issue_refs': issue_refs,
+        'labels': labels,
+        'checks': checks,
+        'reasons': reasons,
+    }
+
+    out = json.dumps(result, ensure_ascii=False, indent=2)
+    Path(env('GITHUB_OUTPUT_JSON', 'merge_gate_result.json')).write_text(out + '\n', encoding='utf-8')
+    print(out)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/governance/release_candidate.py
+++ b/scripts/governance/release_candidate.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def parse_json(name, default):
+    raw = os.environ.get(name, '')
+    if not raw:
+        return default
+    return json.loads(raw)
+
+
+def main():
+    prs = parse_json('MERGED_PRS_JSON', [])
+    commit_sha = os.environ.get('GITHUB_SHA', '')
+    run_url = os.environ.get('GITHUB_SERVER_URL', '') + '/' + os.environ.get('GITHUB_REPOSITORY', '') + '/actions/runs/' + os.environ.get('GITHUB_RUN_ID', '') if os.environ.get('GITHUB_RUN_ID') else ''
+
+    candidate = []
+    blockers = []
+    notes_lines = ['# Release Candidate Snapshot', '']
+
+    for pr in prs:
+        labels = pr.get('labels', [])
+        if 'release/skip' in labels:
+            continue
+        item = {
+            'number': pr.get('number'),
+            'title': pr.get('title'),
+            'labels': labels,
+            'issue_refs': pr.get('issue_refs', []),
+            'merged_at': pr.get('mergedAt', ''),
+        }
+        if 'risk/high' in labels:
+            blockers.append({'pr': pr.get('number'), 'reason': 'risk/high requires manual review'})
+            continue
+        if 'status/done' in labels or 'release/candidate' in labels:
+            candidate.append(item)
+
+    notes_lines.append(f"Generated at: {datetime.now(timezone.utc).isoformat()}")
+    if commit_sha:
+        notes_lines.append(f"Commit: `{commit_sha}`")
+    if run_url:
+        notes_lines.append(f"Run: {run_url}")
+    notes_lines.append('')
+    notes_lines.append('## Candidate PRs')
+    if candidate:
+        for item in candidate:
+            refs = ', '.join(f"#{ref}" for ref in item['issue_refs']) or 'none'
+            notes_lines.append(f"- PR #{item['number']}: {item['title']} | labels={','.join(item['labels']) or 'none'} | issues={refs}")
+    else:
+        notes_lines.append('- none')
+    notes_lines.append('')
+    notes_lines.append('## Blockers')
+    if blockers:
+        for blocker in blockers:
+            notes_lines.append(f"- PR #{blocker['pr']}: {blocker['reason']}")
+    else:
+        notes_lines.append('- none')
+    notes_lines.append('')
+    notes = '\n'.join(notes_lines) + '\n'
+
+    result = {
+        'release_candidate': bool(candidate),
+        'candidate_count': len(candidate),
+        'items': candidate,
+        'blockers': blockers,
+        'commit': commit_sha,
+        'run_url': run_url,
+        'notes_path': 'docs/releases/latest-candidate.md',
+    }
+
+    out = json.dumps(result, ensure_ascii=False, indent=2)
+    Path(os.environ.get('GITHUB_OUTPUT_JSON', 'release_candidate_result.json')).write_text(out + '\n', encoding='utf-8')
+    Path('docs/releases/latest-candidate.json').write_text(out + '\n', encoding='utf-8')
+    Path('docs/releases/latest-candidate.md').write_text(notes, encoding='utf-8')
+    print(out)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## 变更摘要
- 落地 governance execution trio：merge eligibility check、release candidate generator、assignment nudger。
- 对应 round 1 execution MVP 的 workflow + scripts + docs 收口。

## 为什么改
- 将此前仅停留在治理规则层的内容推进到执行层 MVP，先把 merge/release/nudger 做成可运行自动化，而不是继续停在文档。
- 为 issue #10 提供最小可执行闭环，并为后续 checks API 聚合、PR 级 review nudger、release comment 回写打底。

## 如何验证
- 已有 workflow 与脚本提交到 PR。
- 当前历史 checks 中：php-ci 通过；此前阻塞主要来自 PR body 未按治理模板填写。
- 补齐模板后，以当前 workflow 重新校验为准。

## 风险与兼容性
- 风险：本 PR 触及 GitHub Actions workflow 与治理执行脚本，若逻辑判断过宽/过窄，可能影响 merge eligibility、issue nudger 或 release candidate 输出。
- 兼容性：当前仍为 execution MVP，不直接赋予自动 merge / 自动 release / 智能派单权限，只做资格判定、候选生成与提醒。

关联 issue: #10
状态: in-review
风险: medium