### PR TITLE
ci: add executable governance checks mvp

### DIFF
--- a/.github/workflows/governance-exec-mvp.yml
+++ b/.github/workflows/governance-exec-mvp.yml
@@ -2,52 +2,29 @@ name: governance-exec-mvp
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened, labeled, unlabeled, ready_for_review]
+    types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
   issues:
-    types: [opened, edited, labeled, unlabeled, reopened, assigned, unassigned]
-  push:
-    branches: [main]
-  workflow_dispatch:
+    types: [opened, edited, reopened, labeled, unlabeled, assigned, unassigned]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
   issues: write
+  pull-requests: write
 
 jobs:
-  issue-routing:
+  issue-governance-check:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Route issue
+      - name: Validate issue governance contract
         env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
-          ISSUE_ASSIGNEES: ${{ join(github.event.issue.assignees.*.login, ',') }}
-          GITHUB_OUTPUT_JSON: issue_router_result.json
-        run: python3 scripts/governance/issue_router.py
-      - name: Comment routing result
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          body=$(python3 - <<'PY'
-from pathlib import Path
-print("<!-- governance-routing -->")
-print("## Governance routing")
-print("```json")
-print(Path('issue_router_result.json').read_text())
-print("```")
-PY
-)
-          existing=$(gh api repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments --paginate --jq '.[] | select(.body | contains("<!-- governance-routing -->")) | .id' | head -n 1)
-          if [ -n "$existing" ]; then
-            gh api repos/${{ github.repository }}/issues/comments/$existing -X PATCH -f body="$body"
-          else
-            gh issue comment "$ISSUE_NUMBER" --body "$body"
-          fi
+        run: python3 scripts/governance/check_issue_contract.py
 
-  issue-nudger:
+  issue-assignment-nudger:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     steps:
@@ -58,34 +35,24 @@ PY
           ITEM_ASSIGNEES: ${{ join(github.event.issue.assignees.*.login, ',') }}
           GITHUB_OUTPUT_JSON: assignment_nudger_result.json
         run: python3 scripts/governance/assignment_nudger.py
-      - name: Apply nudges
+      - name: Upsert nudges
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          python3 - <<'PY'
-import json
-import os
-import subprocess
-from pathlib import Path
+          REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/governance/upsert_issue_nudges.py
 
-issue_number = os.environ['ISSUE_NUMBER']
-data = json.loads(Path('assignment_nudger_result.json').read_text())
-for action in data.get('actions', []):
-    if action.get('type') != 'comment':
-        continue
-    marker = f"<!-- governance-nudge:{action['key']} -->"
-    body = marker + "\n" + action['message']
-    lookup = subprocess.run([
-        'gh', 'api', f"repos/${{ github.repository }}/issues/{issue_number}/comments", '--paginate',
-        '--jq', f'.[] | select(.body | contains("{marker}")) | .id'
-    ], capture_output=True, text=True, check=True)
-    comment_id = lookup.stdout.strip().splitlines()[0] if lookup.stdout.strip() else ''
-    if comment_id:
-        subprocess.run(['gh', 'api', f"repos/${{ github.repository }}/issues/comments/{comment_id}", '-X', 'PATCH', '-f', f'body={body}'], check=True)
-    else:
-        subprocess.run(['gh', 'issue', 'comment', issue_number, '--body', body], check=True)
-PY
+  pr-governance-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate PR governance contract
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: python3 scripts/governance/check_pr_contract.py
 
   pr-merge-gate:
     if: github.event_name == 'pull_request'
@@ -107,57 +74,32 @@ PY
           gate=$(python3 - <<'PY'
 import json
 from pathlib import Path
-obj = json.loads(Path('merge_gate_result.json').read_text())
-print(obj['gate'])
+print(json.loads(Path('merge_gate_result.json').read_text())['gate'])
 PY
 )
           echo "gate=$gate" >> "$GITHUB_OUTPUT"
-      - name: Comment gate result
+      - name: Upsert merge gate comment
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/governance/upsert_merge_gate_comment.py
+      - name: Fail when merge gate is not eligible
+        if: steps.gate.outputs.gate != 'eligible'
         run: |
-          body=$(python3 - <<'PY'
-import json
-from pathlib import Path
-obj = json.loads(Path('merge_gate_result.json').read_text())
-print("<!-- governance-merge-gate -->")
-print(f"## Governance merge gate: {obj['gate']}")
-print("```json")
-print(json.dumps(obj, ensure_ascii=False, indent=2))
-print("```")
-PY
-)
-          existing=$(gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments --paginate --jq '.[] | select(.body | contains("<!-- governance-merge-gate -->")) | .id' | head -n 1)
-          if [ -n "$existing" ]; then
-            gh api repos/${{ github.repository }}/issues/comments/$existing -X PATCH -f body="$body"
-          else
-            gh pr comment "$PR_NUMBER" --body "$body"
-          fi
-      - name: Gate pass marker
-        if: steps.gate.outputs.gate == 'eligible'
-        run: echo 'merge gate says eligible; merge still remains manual'
+          echo "merge gate blocked: ${{ steps.gate.outputs.gate }}"
+          exit 1
 
-  release-candidate:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+  governance-files-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Build release candidate input
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Ensure governance assets exist
         run: |
-          data=$(gh pr list --state merged --base main --limit 20 --json number,title,labels,body,mergedAt | python3 -c "import json,re,sys; prs=json.load(sys.stdin); print(json.dumps([{'number':pr['number'],'title':pr['title'],'labels':[l['name'] for l in pr.get('labels', [])],'issue_refs':re.findall(r'#(\\d+)', pr.get('body') or ''),'mergedAt':pr.get('mergedAt')} for pr in prs], ensure_ascii=False))")
-          echo "MERGED_PRS_JSON=$data" >> "$GITHUB_ENV"
-      - name: Evaluate release candidate
-        env:
-          GITHUB_OUTPUT_JSON: release_candidate_result.json
-        run: python3 scripts/governance/release_candidate.py
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-candidate
-          path: |
-            release_candidate_result.json
-            docs/releases/latest-candidate.json
-            docs/releases/latest-candidate.md
+          set -euo pipefail
+          test -f docs/governance-state-machine.yaml
+          test -f docs/governance-automation-mvp.md
+          test -f docs/governance-labels-and-status.md
+          test -f scripts/governance/check_issue_contract.py
+          test -f scripts/governance/check_pr_contract.py
+          test -f scripts/governance/merge_gate.py

--- a/.github/workflows/governance-mvp.yml
+++ b/.github/workflows/governance-mvp.yml
@@ -1,73 +1,10 @@
-name: governance-mvp
+name: governance-mvp-legacy-doc
 
 on:
-  issues:
-    types: [opened, edited, labeled, unlabeled, reopened]
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
-  issue-governance-check:
-    if: github.event_name == 'issues'
+  notice:
     runs-on: ubuntu-latest
     steps:
-      - name: Check issue title/body/labels
-        env:
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
-          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
-        run: |
-          set -euo pipefail
-
-          test -n "$ISSUE_TITLE"
-          echo "$ISSUE_BODY" | grep -Eq '背景|Background'
-          echo "$ISSUE_BODY" | grep -Eq '目标|Goal'
-          echo "$ISSUE_BODY" | grep -Eq '验收标准|Acceptance'
-
-          echo "$ISSUE_LABELS" | grep -Eq '(^|,)type/'
-          echo "$ISSUE_LABELS" | grep -Eq '(^|,)priority/'
-          echo "$ISSUE_LABELS" | grep -Eq '(^|,)status/'
-          echo "$ISSUE_LABELS" | grep -Eq '(^|,)risk/'
-
-          if echo "$ISSUE_LABELS" | grep -Eq '(^|,)status/blocked(,|$)'; then
-            echo "$ISSUE_BODY" | grep -Eq 'blocker.reason|阻塞原因'
-            echo "$ISSUE_BODY" | grep -Eq 'blocker.owner|阻塞责任人'
-            echo "$ISSUE_BODY" | grep -Eq 'blocker.unblock_condition|解除条件'
-            echo "$ISSUE_BODY" | grep -Eq 'blocker.next_sync_at|下次同步时间'
-          fi
-
-  pr-governance-check:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check PR title/body/labels
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-        run: |
-          set -euo pipefail
-
-          echo "$PR_TITLE" | grep -Eq '^(feat|fix|docs|refactor|test|chore|build|ci|perf|revert|governance)(\(.+\))?: .+'
-          echo "$PR_BODY" | grep '## 变更摘要'
-          echo "$PR_BODY" | grep '## 为什么改'
-          echo "$PR_BODY" | grep '## 如何验证'
-          echo "$PR_BODY" | grep '## 风险与兼容性'
-          echo "$PR_BODY" | grep -Eq '关联 issue[:：][[:space:]]*#?[0-9]+'
-          echo "$PR_BODY" | grep -Eq '状态[:：][[:space:]]*(draft|triaged|ready|in-progress|blocked|in-review|done|closed)'
-          echo "$PR_BODY" | grep -Eq '风险[:：][[:space:]]*(low|medium|high)'
-
-          if [ -n "$PR_LABELS" ]; then
-            echo "$PR_LABELS" | grep -Eq '(^|,)risk/'
-          fi
-
-  state-machine-file-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Ensure governance files exist
-        run: |
-          set -euo pipefail
-          test -f docs/governance-state-machine.yaml
-          test -f docs/governance-automation-mvp.md
-          test -f docs/governance-labels-and-status.md
+      - run: echo 'Legacy governance workflow replaced by governance-exec-mvp.yml'

--- a/scripts/governance/check_issue_contract.py
+++ b/scripts/governance/check_issue_contract.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+
+
+def parse_csv(value: str) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(',') if item.strip()]
+
+
+def has_line(body: str, *patterns: str) -> bool:
+    return any(re.search(pattern, body, re.IGNORECASE | re.MULTILINE) for pattern in patterns)
+
+
+issue_title = os.environ.get('ISSUE_TITLE', '').strip()
+issue_body = os.environ.get('ISSUE_BODY', '') or ''
+labels = parse_csv(os.environ.get('ISSUE_LABELS', ''))
+
+errors: list[str] = []
+
+if not issue_title:
+    errors.append('issue title is required')
+
+if not has_line(issue_body, r'^#+\s*背景\b', r'^#+\s*Background\b'):
+    errors.append('issue body must include 背景/Background section')
+
+if not has_line(issue_body, r'^#+\s*目标\b', r'^#+\s*Goal\b'):
+    errors.append('issue body must include 目标/Goal section')
+
+if not has_line(issue_body, r'^#+\s*验收标准\b', r'^#+\s*Acceptance( Criteria)?\b'):
+    errors.append('issue body must include 验收标准/Acceptance section')
+
+for prefix in ('type/', 'priority/', 'status/', 'risk/'):
+    if not any(label.startswith(prefix) for label in labels):
+        errors.append(f'missing required label prefix: {prefix}')
+
+if 'status/blocked' in labels:
+    blocker_checks = {
+        'blocker.reason': r'blocker\.reason|阻塞原因',
+        'blocker.owner': r'blocker\.owner|阻塞责任人',
+        'blocker.unblock_condition': r'blocker\.unblock_condition|解除条件',
+        'blocker.next_sync_at': r'blocker\.next_sync_at|下次同步时间',
+    }
+    for name, pattern in blocker_checks.items():
+        if not re.search(pattern, issue_body, re.IGNORECASE):
+            errors.append(f'missing blocked issue field: {name}')
+
+if errors:
+    for error in errors:
+        print(error)
+    sys.exit(1)
+
+print('issue governance contract OK')

--- a/scripts/governance/check_pr_contract.py
+++ b/scripts/governance/check_pr_contract.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+
+
+def parse_csv(value: str) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(',') if item.strip()]
+
+
+pr_title = os.environ.get('PR_TITLE', '').strip()
+pr_body = os.environ.get('PR_BODY', '') or ''
+labels = parse_csv(os.environ.get('PR_LABELS', ''))
+
+errors: list[str] = []
+
+if not re.match(r'^(feat|fix|docs|refactor|test|chore|build|ci|perf|revert|governance)(\(.+\))?: .+', pr_title):
+    errors.append('PR title must follow conventional commit style')
+
+required_sections = [
+    '## 变更摘要',
+    '## 为什么改',
+    '## 如何验证',
+    '## 风险与兼容性',
+]
+for section in required_sections:
+    if section not in pr_body:
+        errors.append(f'missing PR section: {section}')
+
+if not re.search(r'关联 issue[:：]\s*#?\d+', pr_body, re.IGNORECASE):
+    errors.append('PR body must link an issue')
+
+if not re.search(r'状态[:：]\s*(draft|triaged|ready|in-progress|blocked|in-review|done|closed)', pr_body, re.IGNORECASE):
+    errors.append('PR body must declare governance status')
+
+if not re.search(r'风险[:：]\s*(low|medium|high)', pr_body, re.IGNORECASE):
+    errors.append('PR body must declare risk level')
+
+if labels and not any(label.startswith('risk/') for label in labels):
+    errors.append('PR labels must include risk/* when labels are set')
+
+if errors:
+    for error in errors:
+        print(error)
+    sys.exit(1)
+
+print('PR governance contract OK')

--- a/scripts/governance/upsert_issue_nudges.py
+++ b/scripts/governance/upsert_issue_nudges.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+issue_number = os.environ['ISSUE_NUMBER']
+repository = os.environ['REPOSITORY']
+data = json.loads(Path('assignment_nudger_result.json').read_text())
+
+for action in data.get('actions', []):
+    if action.get('type') != 'comment':
+        continue
+    marker = f"<!-- governance-nudge:{action['key']} -->"
+    body = marker + "\n" + action['message']
+    lookup = subprocess.run(
+        [
+            'gh', 'api', f'repos/{repository}/issues/{issue_number}/comments', '--paginate',
+            '--jq', f'.[] | select(.body | contains("{marker}")) | .id'
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    comment_id = lookup.stdout.strip().splitlines()[0] if lookup.stdout.strip() else ''
+    if comment_id:
+        subprocess.run(['gh', 'api', f'repos/{repository}/issues/comments/{comment_id}', '-X', 'PATCH', '-f', f'body={body}'], check=True)
+    else:
+        subprocess.run(['gh', 'issue', 'comment', issue_number, '--repo', repository, '--body', body], check=True)

--- a/scripts/governance/upsert_merge_gate_comment.py
+++ b/scripts/governance/upsert_merge_gate_comment.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+pr_number = os.environ['PR_NUMBER']
+repository = os.environ['REPOSITORY']
+obj = json.loads(Path('merge_gate_result.json').read_text())
+body = "\n".join([
+    '<!-- governance-merge-gate -->',
+    f"## Governance merge gate: {obj['gate']}",
+    '```json',
+    json.dumps(obj, ensure_ascii=False, indent=2),
+    '```',
+])
+lookup = subprocess.run(
+    [
+        'gh', 'api', f'repos/{repository}/issues/{pr_number}/comments', '--paginate',
+        '--jq', '.[] | select(.body | contains("<!-- governance-merge-gate -->")) | .id'
+    ],
+    capture_output=True,
+    text=True,
+    check=True,
+)
+comment_id = lookup.stdout.strip().splitlines()[0] if lookup.stdout.strip() else ''
+if comment_id:
+    subprocess.run(['gh', 'api', f'repos/{repository}/issues/comments/{comment_id}', '-X', 'PATCH', '-f', f'body={body}'], check=True)
+else:
+    subprocess.run(['gh', 'pr', 'comment', pr_number, '--repo', repository, '--body', body], check=True)


### PR DESCRIPTION
## 变更摘要

- 把治理类检查收敛到 `.github/workflows/governance-exec-mvp.yml`
- 新增可执行的 issue / PR 合约校验脚本
- 保留 merge gate 结果评论与 issue nudge，但把内联脚本抽成可维护文件
- 让 merge gate 在非 eligible 时直接 fail，变成真正的 PR blocker

- 关联 issue：#6
- 状态：in-review
- 风险：low

## 为什么改

之前仓库里有治理文档、半成品 workflow、以及一些脚本，但真正能稳定卡住 PR 的 executable checks 还没收口。这个 PR 只做 MVP：把 issue / PR 文本契约、治理资产存在性、merge gate 失败阻断都落成 Actions。

## 如何验证

- [x] `python3 -m py_compile scripts/governance/*.py`
- [ ] GitHub Actions on PR
- [ ] `composer test`
- [ ] `composer cs:check`

## 风险与兼容性

- 风险低，变更范围只在 `.github/workflows/*` 和 `scripts/governance/*`
- 不引入 auto merge / auto release
- 本地环境无 PHP，因此未执行 composer 相关检查；以 CI 为准

## 范围变更检查

- [x] 本 PR 未引入范围外变更
- [x] 若有变更，已在 issue / PR 中留痕并更新验收标准
