### PR TITLE
feat: close exception handler response contract

### DIFF
--- a/src/Core/Exceptions/Handler.php
+++ b/src/Core/Exceptions/Handler.php
@@ -23,33 +23,69 @@ final class Handler implements ExceptionHandler
 
     public function render(Request $request, Throwable $exception): Response
     {
-        $debug = (bool) $this->config->get('app.debug', false);
+        return Response::safeJson([
+            'error' => $this->payload($request, $exception),
+        ], $this->status($exception), $this->headers($exception));
+    }
+
+    private function payload(Request $request, Throwable $exception): array
+    {
+        $payload = [
+            'code' => $this->code($exception),
+            'message' => $this->message($exception),
+        ];
 
         if ($exception instanceof MethodNotAllowedHttpException) {
-            return Response::safeJson([
-                'error' => array_filter([
-                    'code' => $exception->errorCode(),
-                    'message' => $exception->status() >= 500 && !$debug ? 'Internal Server Error' : $exception->getMessage(),
-                    'allowed_methods' => $exception->allowedMethods(),
-                ], static fn (mixed $value): bool => $value !== null),
-            ], $exception->status(), $exception->headers());
+            $payload['allowed_methods'] = $exception->allowedMethods();
         }
 
         if ($exception instanceof HttpException) {
-            return Response::safeJson([
-                'error' => array_filter([
-                    'code' => $exception->errorCode(),
-                    'message' => $exception->status() >= 500 && !$debug ? 'Internal Server Error' : $exception->getMessage(),
-                    ...$exception->meta(),
-                ], static fn (mixed $value): bool => $value !== null),
-            ], $exception->status(), $exception->headers());
+            $payload = [...$payload, ...$exception->meta()];
         }
 
-        return Response::safeJson([
-            'error' => [
-                'code' => 'INTERNAL_SERVER_ERROR',
-                'message' => $debug ? $exception->getMessage() : 'Internal Server Error',
-            ],
-        ], 500);
+        if ($this->debug()) {
+            $payload['debug'] = [
+                'exception' => $exception::class,
+                'message' => $exception->getMessage(),
+                'path' => $request->path(),
+                'method' => $request->method(),
+            ];
+        }
+
+        return array_filter($payload, static fn (mixed $value): bool => $value !== null);
+    }
+
+    private function status(Throwable $exception): int
+    {
+        return $exception instanceof HttpException ? $exception->status() : 500;
+    }
+
+    private function headers(Throwable $exception): array
+    {
+        return $exception instanceof HttpException ? $exception->headers() : [];
+    }
+
+    private function code(Throwable $exception): string
+    {
+        return $exception instanceof HttpException ? $exception->errorCode() : 'INTERNAL_SERVER_ERROR';
+    }
+
+    private function message(Throwable $exception): string
+    {
+        if (!$this->shouldSanitize($exception)) {
+            return $exception->getMessage();
+        }
+
+        return 'Internal Server Error';
+    }
+
+    private function shouldSanitize(Throwable $exception): bool
+    {
+        return $this->status($exception) >= 500 && !$this->debug();
+    }
+
+    private function debug(): bool
+    {
+        return (bool) $this->config->get('app.debug', false);
     }
 }

--- a/tests/Feature/ExceptionHandlingTest.php
+++ b/tests/Feature/ExceptionHandlingTest.php
@@ -17,14 +17,17 @@ final class ExceptionHandlingTest extends KernelTestCase
         self::assertSame(500, $response->status());
         self::assertSame('INTERNAL_SERVER_ERROR', $response->payload()['error']['code']);
         self::assertSame('Internal Server Error', $response->payload()['error']['message']);
+        self::assertArrayNotHasKey('debug', $response->payload()['error']);
     }
 
-    public function test_report_returns_debug_message_when_debug_enabled(): void
+    public function test_report_returns_debug_message_and_context_when_debug_enabled(): void
     {
         $response = (new \Folio\Core\Kernel(dirname(__DIR__, 2)))->report(new RuntimeException('boom'), true);
 
         self::assertSame(500, $response->status());
         self::assertSame('boom', $response->payload()['error']['message']);
+        self::assertSame(RuntimeException::class, $response->payload()['error']['debug']['exception']);
+        self::assertSame('CLI', $response->payload()['error']['debug']['method']);
     }
 
     public function test_http_exceptions_are_rendered_via_single_handler_entry(): void

--- a/tests/Unit/Exceptions/HandlerTest.php
+++ b/tests/Unit/Exceptions/HandlerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Exceptions;
+
+use Folio\Core\Config\ConfigRepository;
+use Folio\Core\Exceptions\Handler;
+use Folio\Core\Exceptions\HttpException;
+use Folio\Core\Exceptions\MethodNotAllowedHttpException;
+use Folio\Core\Http\Request;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class HandlerTest extends TestCase
+{
+    public function test_it_renders_http_exception_payload_via_single_contract(): void
+    {
+        $handler = new Handler(new ConfigRepository(['app' => ['debug' => false]]));
+        $request = new Request('GET', '/missing');
+        $response = $handler->render($request, HttpException::notFound('missing'));
+
+        self::assertSame(404, $response->status());
+        self::assertSame('NOT_FOUND', $response->payload()['error']['code']);
+        self::assertSame('missing', $response->payload()['error']['message']);
+    }
+
+    public function test_it_keeps_allowed_methods_and_allow_header_for_405(): void
+    {
+        $handler = new Handler(new ConfigRepository(['app' => ['debug' => false]]));
+        $request = new Request('POST', '/ping');
+        $exception = new MethodNotAllowedHttpException(['GET'], 'method not allowed');
+        $response = $handler->render($request, $exception);
+
+        self::assertSame(405, $response->status());
+        self::assertSame('GET', $response->headers()['Allow']);
+        self::assertSame(['GET'], $response->payload()['error']['allowed_methods']);
+    }
+
+    public function test_it_sanitizes_500_errors_when_debug_is_disabled(): void
+    {
+        $handler = new Handler(new ConfigRepository(['app' => ['debug' => false]]));
+        $request = new Request('GET', '/boom');
+        $response = $handler->render($request, new RuntimeException('secret failure'));
+
+        self::assertSame(500, $response->status());
+        self::assertSame('Internal Server Error', $response->payload()['error']['message']);
+        self::assertArrayNotHasKey('debug', $response->payload()['error']);
+    }
+
+    public function test_it_exposes_debug_context_when_debug_is_enabled(): void
+    {
+        $handler = new Handler(new ConfigRepository(['app' => ['debug' => true]]));
+        $request = new Request('DELETE', '/boom');
+        $response = $handler->render($request, new RuntimeException('secret failure'));
+
+        self::assertSame(500, $response->status());
+        self::assertSame('secret failure', $response->payload()['error']['message']);
+        self::assertSame(RuntimeException::class, $response->payload()['error']['debug']['exception']);
+        self::assertSame('/boom', $response->payload()['error']['debug']['path']);
+        self::assertSame('DELETE', $response->payload()['error']['debug']['method']);
+    }
+}


### PR DESCRIPTION
## 变更摘要
- 收口 Exception Handler 的 JSON 响应出口，统一 status/code/message/headers 判定
- 为 debug 模式补充结构化 debug context（exception/path/method）
- 补充 Handler 单测与 feature 断言，覆盖 404/405/500/debug 场景

## 为什么改
- 当前 runtime 已统一走共享异常处理器，但 handler 输出合同仍偏散，debug 信息与 http/meta 合并逻辑没有单点约束
- 这条线最值钱，因为它直接定义框架对外错误面，后续 middleware / provider 生命周期都得围着这个合同长

## 如何验证
- 由于当前环境缺 php，未在本机执行 phpunit
- 依赖 CI 运行 tests / cs checks
- 新增 tests/Unit/Exceptions/HandlerTest.php 覆盖核心合同

## 风险与兼容性
- 变更 500 debug 响应体，新增 error.debug 字段（仅 debug=true）
- 405 继续保留 Allow header 与 allowed_methods
- 非 debug 500 仍保持脱敏，不扩大泄漏面

关联 issue: #20
状态: Ready for review
风险: Low