### PR TITLE
feat: add middleware pipeline contract and alpha trace

### DIFF
--- a/app/Http/Middleware/AlphaRequestTrace.php
+++ b/app/Http/Middleware/AlphaRequestTrace.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Folio\Core\Contracts\Http\Middleware;
+use Folio\Core\Http\Request;
+use Folio\Core\Http\Response;
+
+final class AlphaRequestTrace implements Middleware
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+        $payload = $response->payload();
+        $payload['meta'] = array_replace($payload['meta'] ?? [], [
+            'alpha' => [
+                'request_trace' => sprintf('%s %s', $request->method(), $request->path()),
+            ],
+        ]);
+
+        return Response::json($payload, $response->status(), $response->headers());
+    }
+}

--- a/app/Http/Middleware/TrimStrings.php
+++ b/app/Http/Middleware/TrimStrings.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Http\Middleware;
 
 use Closure;
+use Folio\Core\Contracts\Http\Middleware;
 use Folio\Core\Http\Request;
 use Folio\Core\Http\Response;
 
-final class TrimStrings
+final class TrimStrings implements Middleware
 {
     public function handle(Request $request, Closure $next): Response
     {

--- a/config/app.php
+++ b/config/app.php
@@ -6,7 +6,9 @@ return [
     'debug' => (bool) env('APP_DEBUG', false),
     'locale' => env('APP_LOCALE', 'zh-CN'),
     'fallback_locale' => env('APP_FALLBACK_LOCALE', 'zh-CN'),
-    'middleware' => [],
+    'middleware' => [
+        \App\Http\Middleware\AlphaRequestTrace::class,
+    ],
     'providers' => [
         \Folio\Core\Providers\TranslationServiceProvider::class,
     ],

--- a/src/Core/Application/Application.php
+++ b/src/Core/Application/Application.php
@@ -9,6 +9,7 @@ use Folio\Core\Config\ConfigRepository;
 use Folio\Core\Config\Env;
 use Folio\Core\Container\Container;
 use Folio\Core\Contracts\Debug\ExceptionHandler;
+use Folio\Core\Contracts\Http\Middleware as MiddlewareContract;
 use Folio\Core\Contracts\ServiceProvider;
 use Folio\Core\Contracts\Support\DeferrableProvider;
 use Folio\Core\Http\MiddlewarePipeline;
@@ -33,7 +34,7 @@ final class Application
     /** @var array<class-string<ServiceProvider>, bool> */
     private array $bootedProviders = [];
 
-    /** @var list<class-string|object|callable> */
+    /** @var list<class-string<MiddlewareContract>|MiddlewareContract|callable> */
     private array $middlewares = [];
 
     public function __construct(private readonly string $basePath)
@@ -125,9 +126,30 @@ final class Application
         return $this->container->make($abstract, $parameters);
     }
 
+    /** @param list<class-string<MiddlewareContract>|MiddlewareContract|callable> $middlewares */
     public function withMiddleware(array $middlewares): self
     {
-        $this->middlewares = $middlewares;
+        $this->middlewares = array_values($middlewares);
+
+        return $this;
+    }
+
+    /** @return list<class-string<MiddlewareContract>|MiddlewareContract|callable> */
+    public function middleware(): array
+    {
+        return $this->middlewares;
+    }
+
+    public function appendMiddleware(string|MiddlewareContract|callable $middleware): self
+    {
+        $this->middlewares[] = $middleware;
+
+        return $this;
+    }
+
+    public function prependMiddleware(string|MiddlewareContract|callable $middleware): self
+    {
+        array_unshift($this->middlewares, $middleware);
 
         return $this;
     }
@@ -136,10 +158,13 @@ final class Application
     {
         $router = $this->make(Router::class);
         $config = $this->make(ConfigRepository::class);
-        $middleware = $config->get('app.middleware', []);
+        $configured = $config->get('app.middleware', []);
         $pipeline = new MiddlewarePipeline(
             $this->container,
-            is_array($middleware) ? $middleware : $this->middlewares,
+            [
+                ...(is_array($configured) ? array_values($configured) : []),
+                ...$this->middlewares,
+            ],
         );
 
         try {

--- a/src/Core/Contracts/Foundation/Application.php
+++ b/src/Core/Contracts/Foundation/Application.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Folio\Core\Contracts\Foundation;
 
 use Folio\Core\Contracts\Container\Container;
+use Folio\Core\Contracts\Http\Middleware;
+use Folio\Core\Contracts\ServiceProvider;
 use Folio\Core\Http\Request;
 use Folio\Core\Http\Response;
-use Folio\Core\Contracts\ServiceProvider;
 
 interface Application extends Container
 {
@@ -16,6 +17,14 @@ interface Application extends Container
     public function basePath(string $path = ''): string;
 
     public function bootstrap(): self;
+
+    public function withMiddleware(array $middlewares): self;
+
+    public function prependMiddleware(string|Middleware|callable $middleware): self;
+
+    public function appendMiddleware(string|Middleware|callable $middleware): self;
+
+    public function middleware(): array;
 
     public function handle(Request $request): Response;
 

--- a/src/Core/Contracts/Http/Middleware.php
+++ b/src/Core/Contracts/Http/Middleware.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Folio\Core\Contracts\Http;
+
+use Closure;
+use Folio\Core\Http\Request;
+use Folio\Core\Http\Response;
+
+interface Middleware
+{
+    public function handle(Request $request, Closure $next): Response;
+}

--- a/src/Core/Foundation/Application.php
+++ b/src/Core/Foundation/Application.php
@@ -9,10 +9,11 @@ use Folio\Core\Config\ConfigRepository;
 use Folio\Core\Container\Container;
 use Folio\Core\Contracts\Debug\ExceptionHandler;
 use Folio\Core\Contracts\Foundation\Application as ApplicationContract;
+use Folio\Core\Contracts\Http\Middleware as MiddlewareContract;
+use Folio\Core\Contracts\ServiceProvider;
 use Folio\Core\Contracts\Support\DeferrableProvider;
 use Folio\Core\Http\Request;
 use Folio\Core\Http\Response;
-use Folio\Core\Contracts\ServiceProvider;
 use Throwable;
 
 final class Application implements ApplicationContract
@@ -57,6 +58,32 @@ final class Application implements ApplicationContract
         $this->bootstrapped = true;
 
         return $this;
+    }
+
+    public function withMiddleware(array $middlewares): self
+    {
+        $this->application->withMiddleware($middlewares);
+
+        return $this;
+    }
+
+    public function prependMiddleware(string|MiddlewareContract|callable $middleware): self
+    {
+        $this->application->prependMiddleware($middleware);
+
+        return $this;
+    }
+
+    public function appendMiddleware(string|MiddlewareContract|callable $middleware): self
+    {
+        $this->application->appendMiddleware($middleware);
+
+        return $this;
+    }
+
+    public function middleware(): array
+    {
+        return $this->application->middleware();
     }
 
     public function handle(Request $request): Response

--- a/src/Core/Http/MiddlewarePipeline.php
+++ b/src/Core/Http/MiddlewarePipeline.php
@@ -6,10 +6,12 @@ namespace Folio\Core\Http;
 
 use Closure;
 use Folio\Core\Container\Container;
+use Folio\Core\Contracts\Http\Middleware as MiddlewareContract;
+use InvalidArgumentException;
 
 final class MiddlewarePipeline
 {
-    /** @param list<class-string|object|callable> $middlewares */
+    /** @param list<class-string<MiddlewareContract>|MiddlewareContract|callable> $middlewares */
     public function __construct(
         private readonly Container $container,
         private readonly array $middlewares = [],
@@ -29,14 +31,37 @@ final class MiddlewarePipeline
 
     private function handle(mixed $middleware, Request $request, Closure $next): Response
     {
+        $resolved = $this->resolve($middleware);
+
+        if (is_callable($resolved)) {
+            $response = $resolved($request, $next);
+        } elseif ($resolved instanceof MiddlewareContract) {
+            $response = $resolved->handle($request, $next);
+        } else {
+            throw new InvalidArgumentException(sprintf(
+                'Middleware [%s] must be a callable or implement %s.',
+                is_object($resolved) ? $resolved::class : gettype($resolved),
+                MiddlewareContract::class,
+            ));
+        }
+
+        if (!$response instanceof Response) {
+            throw new InvalidArgumentException(sprintf(
+                'Middleware [%s] must return %s.',
+                is_object($resolved) ? $resolved::class : gettype($resolved),
+                Response::class,
+            ));
+        }
+
+        return $response;
+    }
+
+    private function resolve(mixed $middleware): mixed
+    {
         if (is_string($middleware)) {
-            $middleware = $this->container->make($middleware);
+            return $this->container->make($middleware);
         }
 
-        if (is_callable($middleware)) {
-            return $middleware($request, $next);
-        }
-
-        return $middleware->handle($request, $next);
+        return $middleware;
     }
 }

--- a/tests/Feature/HealthEndpointTest.php
+++ b/tests/Feature/HealthEndpointTest.php
@@ -12,13 +12,9 @@ final class HealthEndpointTest extends KernelTestCase
 
         self::assertSame(200, $response->status());
         self::assertSame('application/json; charset=utf-8', $response->headers()['Content-Type']);
-        self::assertSame(
-            [
-                'status' => 'ok',
-                'app' => 'Folio',
-                'env' => 'local',
-            ],
-            $response->payload()
-        );
+        self::assertSame('ok', $response->payload()['status']);
+        self::assertSame('Folio', $response->payload()['app']);
+        self::assertSame('local', $response->payload()['env']);
+        self::assertSame('GET /health', $response->payload()['meta']['alpha']['request_trace']);
     }
 }

--- a/tests/Feature/PingEndpointTest.php
+++ b/tests/Feature/PingEndpointTest.php
@@ -12,12 +12,8 @@ final class PingEndpointTest extends KernelTestCase
 
         self::assertSame(200, $response->status());
         self::assertSame('application/json; charset=utf-8', $response->headers()['Content-Type']);
-        self::assertSame(
-            [
-                'message' => 'pong',
-                'locale' => 'zh-CN',
-            ],
-            $response->payload()
-        );
+        self::assertSame('pong', $response->payload()['message']);
+        self::assertSame('zh-CN', $response->payload()['locale']);
+        self::assertSame('GET /api/v1/ping', $response->payload()['meta']['alpha']['request_trace']);
     }
 }

--- a/tests/Feature/RuntimeFlowTest.php
+++ b/tests/Feature/RuntimeFlowTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Folio\Core\Application\Application;
+use Folio\Core\Contracts\Debug\ExceptionHandler;
 use Folio\Core\Http\Request;
+use Folio\Core\Http\Response;
 use RuntimeException;
+use Throwable;
 
 final class RuntimeFlowTest extends KernelTestCase
 {
@@ -19,6 +22,7 @@ final class RuntimeFlowTest extends KernelTestCase
         self::assertSame(200, $response->status());
         self::assertSame('ok', $response->payload()['status']);
         self::assertSame('Folio', $response->payload()['app']);
+        self::assertSame('GET /health', $response->payload()['meta']['alpha']['request_trace']);
     }
 
     public function test_runtime_application_converts_router_exceptions_via_shared_handler(): void
@@ -43,5 +47,93 @@ final class RuntimeFlowTest extends KernelTestCase
 
         self::assertSame(500, $response->status());
         self::assertSame('Internal Server Error', $response->payload()['error']['message']);
+    }
+
+    public function test_runtime_application_routes_middleware_exceptions_to_exception_handler(): void
+    {
+        $application = (new Application(dirname(__DIR__, 2)))->bootstrap();
+        $handler = new RecordingExceptionHandler();
+        $application->container()->instance(ExceptionHandler::class, $handler);
+        $application->prependMiddleware(static function (): never {
+            throw new RuntimeException('middleware boom');
+        });
+
+        $response = $application->handle(new Request('GET', '/health'));
+
+        self::assertSame(500, $response->status());
+        self::assertSame('HANDLED_BY_TEST', $response->payload()['error']['code']);
+        self::assertSame('middleware boom', $handler->reported?->getMessage());
+        self::assertSame('middleware boom', $handler->rendered?->getMessage());
+    }
+
+    public function test_runtime_application_supports_programmatic_global_middleware_ordering(): void
+    {
+        $application = (new Application(dirname(__DIR__, 2)))->bootstrap()->withMiddleware([]);
+        $trace = [];
+
+        $application
+            ->appendMiddleware(static function (Request $request, callable $next) use (&$trace): Response {
+                $trace[] = 'append-before';
+                $response = $next($request);
+                $trace[] = 'append-after';
+
+                return $response;
+            })
+            ->prependMiddleware(static function (Request $request, callable $next) use (&$trace): Response {
+                $trace[] = 'prepend-before';
+                $response = $next($request);
+                $trace[] = 'prepend-after';
+
+                return $response;
+            });
+
+        $response = $application->handle(new Request('GET', '/health'));
+
+        self::assertSame(200, $response->status());
+        self::assertSame([
+            'prepend-before',
+            'append-before',
+            'append-after',
+            'prepend-after',
+        ], $trace);
+    }
+
+    public function test_runtime_application_supports_programmatic_short_circuit_middleware(): void
+    {
+        $application = (new Application(dirname(__DIR__, 2)))->bootstrap()->withMiddleware([]);
+        $application->appendMiddleware(static function (): Response {
+            return Response::json(['maintenance' => true], 503);
+        });
+
+        $response = $application->handle(new Request('GET', '/health'));
+
+        self::assertSame(503, $response->status());
+        self::assertSame(true, $response->payload()['maintenance']);
+        self::assertSame('GET /health', $response->payload()['meta']['alpha']['request_trace']);
+    }
+}
+
+final class RecordingExceptionHandler implements ExceptionHandler
+{
+    public ?Throwable $reported = null;
+
+    public ?Throwable $rendered = null;
+
+    public function report(Throwable $exception): void
+    {
+        $this->reported = $exception;
+    }
+
+    public function render(Request $request, Throwable $exception): Response
+    {
+        $this->rendered = $exception;
+
+        return Response::json([
+            'error' => [
+                'code' => 'HANDLED_BY_TEST',
+                'message' => $exception->getMessage(),
+                'path' => $request->path(),
+            ],
+        ], 500);
     }
 }

--- a/tests/Unit/Http/MiddlewarePipelineTest.php
+++ b/tests/Unit/Http/MiddlewarePipelineTest.php
@@ -6,10 +6,12 @@ namespace Tests\Unit\Http;
 
 use Closure;
 use Folio\Core\Container\Container;
+use Folio\Core\Contracts\Http\Middleware as MiddlewareContract;
 use Folio\Core\Http\MiddlewarePipeline;
 use Folio\Core\Http\Request;
 use Folio\Core\Http\Response;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class MiddlewarePipelineTest extends TestCase
 {
@@ -39,5 +41,75 @@ final class MiddlewarePipelineTest extends TestCase
 
         self::assertSame(200, $response->status());
         self::assertSame(['mw1-before', 'mw2-before', 'mw2-after', 'mw1-after'], $trace);
+    }
+
+    public function test_pipeline_short_circuits_when_middleware_returns_response_without_calling_next(): void
+    {
+        $trace = [];
+        $pipeline = new MiddlewarePipeline(new Container(), [
+            static function (Request $request, Closure $next) use (&$trace): Response {
+                $trace[] = 'mw1-before';
+                $response = $next($request);
+                $trace[] = 'mw1-after';
+
+                return $response;
+            },
+            static function (Request $request, Closure $next) use (&$trace): Response {
+                $trace[] = 'mw2-short-circuit';
+
+                return Response::json(['short' => true], 202);
+            },
+        ]);
+
+        $response = $pipeline->process(new Request('GET', '/health'), static function () use (&$trace): Response {
+            $trace[] = 'destination';
+
+            return Response::json(['ok' => true]);
+        });
+
+        self::assertSame(202, $response->status());
+        self::assertSame(['short' => true], $response->payload());
+        self::assertSame(['mw1-before', 'mw2-short-circuit', 'mw1-after'], $trace);
+    }
+
+    public function test_pipeline_resolves_class_string_middlewares_from_container(): void
+    {
+        $container = new Container();
+        $container->instance(TraceMiddleware::class, new TraceMiddleware());
+        $pipeline = new MiddlewarePipeline($container, [TraceMiddleware::class]);
+
+        $response = $pipeline->process(new Request('GET', '/health'), static function (): Response {
+            return Response::json(['ok' => true]);
+        });
+
+        self::assertSame(['ok' => true, 'trace' => 'class-string'], $response->payload());
+    }
+
+    public function test_pipeline_bubbles_middleware_exceptions_to_caller(): void
+    {
+        $pipeline = new MiddlewarePipeline(new Container(), [
+            static function (): never {
+                throw new RuntimeException('middleware exploded');
+            },
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('middleware exploded');
+
+        $pipeline->process(new Request('GET', '/boom'), static function (): Response {
+            return Response::json(['ok' => true]);
+        });
+    }
+}
+
+final class TraceMiddleware implements MiddlewareContract
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        return Response::json(array_replace($response->payload(), [
+            'trace' => 'class-string',
+        ]), $response->status(), $response->headers());
     }
 }


### PR DESCRIPTION
## Summary
- add a first-class HTTP middleware contract plus global registration APIs on the foundation/runtime application
- preserve declared before/after pipeline order, support short-circuit responses, and route middleware failures through ExceptionHandler
- ship an alpha example middleware that injects request trace metadata and cover the flow with unit/feature tests

## Verification
- /opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit

## Notes
- config/app.php now wires the alpha middleware example by default
