### PR TITLE
feat: add alpha route parameter binding

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -17,4 +17,14 @@ return static function (Router $router, string $locale, string $pingMessage): vo
             'locale' => $locale,
         ]);
     });
+
+    $router->get('/api/v1/users/{user}', static function (Request $request) use ($locale): Response {
+        return Response::json([
+            'data' => [
+                'user' => $request->routeParameter('user'),
+                'route_parameters' => $request->routeParameters(),
+            ],
+            'locale' => $locale,
+        ]);
+    });
 };

--- a/src/Core/Http/Request.php
+++ b/src/Core/Http/Request.php
@@ -6,12 +6,14 @@ namespace Folio\Core\Http;
 
 final class Request
 {
+    /** @param array<string, string> $routeParameters */
     public function __construct(
         private readonly string $method,
         private readonly string $path,
         private readonly array $query = [],
         private readonly array $server = [],
         private readonly mixed $body = null,
+        private readonly array $routeParameters = [],
     ) {
     }
 
@@ -55,5 +57,29 @@ final class Request
     public function body(): mixed
     {
         return $this->body;
+    }
+
+    /** @return array<string, string> */
+    public function routeParameters(): array
+    {
+        return $this->routeParameters;
+    }
+
+    public function routeParameter(string $key, mixed $default = null): mixed
+    {
+        return $this->routeParameters[$key] ?? $default;
+    }
+
+    /** @param array<string, string> $parameters */
+    public function withRouteParameters(array $parameters): self
+    {
+        return new self(
+            method: $this->method,
+            path: $this->path,
+            query: $this->query,
+            server: $this->server,
+            body: $this->body,
+            routeParameters: $parameters,
+        );
     }
 }

--- a/src/Core/Routing/Router.php
+++ b/src/Core/Routing/Router.php
@@ -12,7 +12,7 @@ use Folio\Core\Http\Response;
 
 final class Router
 {
-    /** @var array<string, array<string, Closure(Request): Response>> */
+    /** @var array<string, array<int, array{path: string, handler: Closure(Request): Response, pattern: string, parameters: list<string>}>> */
     private array $routes = [];
 
     public function get(string $path, Closure $handler): void
@@ -22,17 +22,23 @@ final class Router
 
     public function map(string $method, string $path, Closure $handler): void
     {
-        $this->routes[strtoupper($method)][$path] = $handler;
+        $normalizedPath = $this->normalizePath($path);
+        $this->routes[strtoupper($method)][] = [
+            'path' => $normalizedPath,
+            'handler' => $handler,
+            'pattern' => $this->compilePathPattern($normalizedPath),
+            'parameters' => $this->extractParameterNames($normalizedPath),
+        ];
     }
 
     public function dispatch(Request $request): Response
     {
         $method = strtoupper($request->method());
-        $path = $request->path();
-        $handler = $this->routes[$method][$path] ?? null;
+        $path = $this->normalizePath($request->path());
+        $matchedRoute = $this->matchRoute($method, $path);
 
-        if ($handler instanceof Closure) {
-            return $handler($request);
+        if ($matchedRoute !== null) {
+            return $matchedRoute['handler']($request->withRouteParameters($matchedRoute['parameters']));
         }
 
         if ($this->hasPath($path)) {
@@ -44,8 +50,8 @@ final class Router
 
     private function hasPath(string $path): bool
     {
-        foreach ($this->routes as $routes) {
-            if (array_key_exists($path, $routes)) {
+        foreach (array_keys($this->routes) as $method) {
+            if ($this->matchRoute($method, $path) !== null) {
                 return true;
             }
         }
@@ -58,8 +64,8 @@ final class Router
     {
         $allowed = [];
 
-        foreach ($this->routes as $method => $routes) {
-            if (array_key_exists($path, $routes)) {
+        foreach (array_keys($this->routes) as $method) {
+            if ($this->matchRoute($method, $path) !== null) {
                 $allowed[] = $method;
             }
         }
@@ -67,5 +73,64 @@ final class Router
         sort($allowed);
 
         return $allowed;
+    }
+
+    /** @return array{handler: Closure(Request): Response, parameters: array<string, string>}|null */
+    private function matchRoute(string $method, string $path): ?array
+    {
+        foreach ($this->routes[$method] ?? [] as $route) {
+            if (preg_match($route['pattern'], $path, $matches) !== 1) {
+                continue;
+            }
+
+            $parameters = [];
+            foreach ($route['parameters'] as $parameter) {
+                if (isset($matches[$parameter])) {
+                    $parameters[$parameter] = $matches[$parameter];
+                }
+            }
+
+            return [
+                'handler' => $route['handler'],
+                'parameters' => $parameters,
+            ];
+        }
+
+        return null;
+    }
+
+    private function normalizePath(string $path): string
+    {
+        if ($path === '' || $path === '/') {
+            return '/';
+        }
+
+        return '/'.trim($path, '/');
+    }
+
+    private function compilePathPattern(string $path): string
+    {
+        $segments = explode('/', trim($path, '/'));
+        $compiled = array_map(static function (string $segment): string {
+            if (preg_match('/^\{([A-Za-z_][A-Za-z0-9_]*)\}$/', $segment, $matches) === 1) {
+                return '(?P<'.$matches[1].'>[^/]+)';
+            }
+
+            return preg_quote($segment, '#');
+        }, $segments);
+
+        if ($compiled === []) {
+            return '#^/$#';
+        }
+
+        return '#^/'.implode('/', $compiled).'$#';
+    }
+
+    /** @return list<string> */
+    private function extractParameterNames(string $path): array
+    {
+        preg_match_all('/\{([A-Za-z_][A-Za-z0-9_]*)\}/', $path, $matches);
+
+        return $matches[1] ?? [];
     }
 }

--- a/tests/Feature/PingEndpointTest.php
+++ b/tests/Feature/PingEndpointTest.php
@@ -16,4 +16,14 @@ final class PingEndpointTest extends KernelTestCase
         self::assertSame('zh-CN', $response->payload()['locale']);
         self::assertSame('GET /api/v1/ping', $response->payload()['meta']['alpha']['request_trace']);
     }
+
+    public function test_dynamic_route_returns_bound_route_parameters(): void
+    {
+        $response = $this->dispatch('GET', '/api/v1/users/42');
+
+        self::assertSame(200, $response->status());
+        self::assertSame('42', $response->payload()['data']['user']);
+        self::assertSame(['user' => '42'], $response->payload()['data']['route_parameters']);
+        self::assertSame('GET /api/v1/users/42', $response->payload()['meta']['alpha']['request_trace']);
+    }
 }

--- a/tests/Unit/Routing/RouterTest.php
+++ b/tests/Unit/Routing/RouterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Routing;
+
+use Folio\Core\Exceptions\MethodNotAllowedHttpException;
+use Folio\Core\Exceptions\NotFoundHttpException;
+use Folio\Core\Http\Request;
+use Folio\Core\Http\Response;
+use Folio\Core\Routing\Router;
+use PHPUnit\Framework\TestCase;
+
+final class RouterTest extends TestCase
+{
+    public function test_router_dispatches_dynamic_route_and_hydrates_request_route_parameters(): void
+    {
+        $router = new Router();
+        $router->get('/api/v1/users/{user}', static function (Request $request): Response {
+            return Response::json([
+                'user' => $request->routeParameter('user'),
+                'all' => $request->routeParameters(),
+            ]);
+        });
+
+        $response = $router->dispatch(new Request('GET', '/api/v1/users/42'));
+
+        self::assertSame(200, $response->status());
+        self::assertSame('42', $response->payload()['user']);
+        self::assertSame(['user' => '42'], $response->payload()['all']);
+    }
+
+    public function test_router_reports_method_not_allowed_for_dynamic_route_pattern(): void
+    {
+        $router = new Router();
+        $router->get('/api/v1/users/{user}', static fn (): Response => Response::json(['ok' => true]));
+
+        $this->expectException(MethodNotAllowedHttpException::class);
+        $router->dispatch(new Request('POST', '/api/v1/users/42'));
+    }
+
+    public function test_router_throws_not_found_when_dynamic_route_pattern_does_not_match(): void
+    {
+        $router = new Router();
+        $router->get('/api/v1/users/{user}', static fn (): Response => Response::json(['ok' => true]));
+
+        $this->expectException(NotFoundHttpException::class);
+        $router->dispatch(new Request('GET', '/api/v1/users/42/posts'));
+    }
+}


### PR DESCRIPTION
## 变更摘要
- 增加 alpha 阶段的动态参数路由匹配能力（如 `/users/{id}`）
- 将提取出的路由参数绑定到 Request，供 handler 读取
- 补充动态分发、405 行为与基础功能流测试

## 为什么改
- 承接 #43，把 Folio 从静态 path demo router 推进到可支撑小型 API 设计的第一波 routing 扩展
- 在不突破当前 alpha 边界的前提下，优先补齐最值钱的路由能力缺口

## 如何验证
- `/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit`
- 覆盖动态参数命中、参数读取、405 行为与基础路由流程

## 风险与兼容性
- 变更集中在 alpha routing 行为扩展，不引入 db / auth / session / queue 等非目标能力
- 风险在于动态匹配规则若处理不稳会影响既有静态路由分发；已补测试约束现有行为边界

关联 issue: #43
状态: ready for review
风险: low
