### PR TITLE
feat: add router group prefix and named route placeholder

### DIFF
--- a/src/Core/Routing/RouteDefinition.php
+++ b/src/Core/Routing/RouteDefinition.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Folio\Core\Routing;
+
+final class RouteDefinition
+{
+    public function __construct(
+        private readonly Router $router,
+        private readonly string $method,
+        private readonly int $index,
+    ) {
+    }
+
+    public function name(string $name): self
+    {
+        $this->router->setRouteName($this->method, $this->index, $name);
+
+        return $this;
+    }
+}

--- a/src/Core/Routing/Router.php
+++ b/src/Core/Routing/Router.php
@@ -12,23 +12,74 @@ use Folio\Core\Http\Response;
 
 final class Router
 {
-    /** @var array<string, array<int, array{path: string, handler: Closure(Request): Response, pattern: string, parameters: list<string>}>> */
+    /** @var array<string, array<int, array{path: string, handler: Closure(Request): Response, pattern: string, parameters: list<string>, name: ?string}>> */
     private array $routes = [];
 
-    public function get(string $path, Closure $handler): void
+    /** @var list<string> */
+    private array $prefixStack = [];
+
+    /** @var list<string> */
+    private array $nameStack = [];
+
+    public function get(string $path, Closure $handler): RouteDefinition
     {
-        $this->map('GET', $path, $handler);
+        return $this->map('GET', $path, $handler);
     }
 
-    public function map(string $method, string $path, Closure $handler): void
+    public function map(string $method, string $path, Closure $handler): RouteDefinition
     {
-        $normalizedPath = $this->normalizePath($path);
-        $this->routes[strtoupper($method)][] = [
+        $normalizedPath = $this->applyPrefix($path);
+        $route = [
             'path' => $normalizedPath,
             'handler' => $handler,
             'pattern' => $this->compilePathPattern($normalizedPath),
             'parameters' => $this->extractParameterNames($normalizedPath),
+            'name' => $this->currentNamePrefix(),
         ];
+
+        $method = strtoupper($method);
+        $index = isset($this->routes[$method]) ? count($this->routes[$method]) : 0;
+        $this->routes[$method][] = $route;
+
+        return new RouteDefinition($this, $method, $index);
+    }
+
+    public function group(string $prefix, Closure $routes, string $name = ''): void
+    {
+        $normalizedPrefix = $this->normalizeGroupPrefix($prefix);
+        $normalizedName = $this->normalizeNameFragment($name);
+
+        if ($normalizedPrefix !== '') {
+            $this->prefixStack[] = $normalizedPrefix;
+        }
+
+        if ($normalizedName !== '') {
+            $this->nameStack[] = $normalizedName;
+        }
+
+        try {
+            $routes($this);
+        } finally {
+            if ($normalizedName !== '') {
+                array_pop($this->nameStack);
+            }
+
+            if ($normalizedPrefix !== '') {
+                array_pop($this->prefixStack);
+            }
+        }
+    }
+
+    public function prefix(string $prefix, Closure $routes): void
+    {
+        $this->group($prefix, $routes);
+    }
+
+    public function routeName(string $method, string $path): ?string
+    {
+        $matchedRoute = $this->matchRoute(strtoupper($method), $this->normalizePath($path));
+
+        return $matchedRoute['name'] ?? null;
     }
 
     public function dispatch(Request $request): Response
@@ -46,6 +97,14 @@ final class Router
         }
 
         throw new NotFoundHttpException();
+    }
+
+    public function setRouteName(string $method, int $index, string $name): void
+    {
+        $normalized = $this->normalizeNameFragment($name, allowTrailingDot: false);
+        $fullName = $this->currentNamePrefix().$normalized;
+
+        $this->routes[$method][$index]['name'] = $fullName;
     }
 
     private function hasPath(string $path): bool
@@ -75,7 +134,7 @@ final class Router
         return $allowed;
     }
 
-    /** @return array{handler: Closure(Request): Response, parameters: array<string, string>}|null */
+    /** @return array{handler: Closure(Request): Response, parameters: array<string, string>, name: ?string}|null */
     private function matchRoute(string $method, string $path): ?array
     {
         foreach ($this->routes[$method] ?? [] as $route) {
@@ -93,6 +152,7 @@ final class Router
             return [
                 'handler' => $route['handler'],
                 'parameters' => $parameters,
+                'name' => $route['name'],
             ];
         }
 
@@ -106,6 +166,31 @@ final class Router
         }
 
         return '/'.trim($path, '/');
+    }
+
+    private function applyPrefix(string $path): string
+    {
+        $prefix = implode('/', $this->prefixStack);
+        $suffix = trim($path, '/');
+
+        if ($prefix === '' && $suffix === '') {
+            return '/';
+        }
+
+        if ($prefix === '') {
+            return '/'.$suffix;
+        }
+
+        if ($suffix === '') {
+            return '/'.$prefix;
+        }
+
+        return '/'.$prefix.'/'.$suffix;
+    }
+
+    private function normalizeGroupPrefix(string $prefix): string
+    {
+        return trim($prefix, '/');
     }
 
     private function compilePathPattern(string $path): string
@@ -132,5 +217,21 @@ final class Router
         preg_match_all('/\{([A-Za-z_][A-Za-z0-9_]*)\}/', $path, $matches);
 
         return $matches[1] ?? [];
+    }
+
+    private function currentNamePrefix(): string
+    {
+        return implode('', $this->nameStack);
+    }
+
+    private function normalizeNameFragment(string $name, bool $allowTrailingDot = true): string
+    {
+        $normalized = trim($name, '. ');
+
+        if ($normalized === '') {
+            return '';
+        }
+
+        return $allowTrailingDot ? $normalized.'.' : $normalized;
     }
 }

--- a/tests/Unit/Routing/RouterTest.php
+++ b/tests/Unit/Routing/RouterTest.php
@@ -47,4 +47,70 @@ final class RouterTest extends TestCase
         $this->expectException(NotFoundHttpException::class);
         $router->dispatch(new Request('GET', '/api/v1/users/42/posts'));
     }
+
+    public function test_router_prefix_group_scopes_routes_without_leaking_to_following_routes(): void
+    {
+        $router = new Router();
+
+        $router->group('/api/v1', static function (Router $router): void {
+            $router->get('/users/{user}', static function (Request $request): Response {
+                return Response::json([
+                    'user' => $request->routeParameter('user'),
+                    'all' => $request->routeParameters(),
+                ]);
+            });
+        });
+
+        $router->get('/health', static fn (): Response => Response::json(['ok' => true]));
+
+        $grouped = $router->dispatch(new Request('GET', '/api/v1/users/42'));
+        $root = $router->dispatch(new Request('GET', '/health'));
+
+        self::assertSame(['user' => '42', 'all' => ['user' => '42']], $grouped->payload());
+        self::assertSame(['ok' => true], $root->payload());
+    }
+
+    public function test_router_nested_group_composes_prefix_boundaries_correctly(): void
+    {
+        $router = new Router();
+
+        $router->group('/api', static function (Router $router): void {
+            $router->group('/v1', static function (Router $router): void {
+                $router->get('/teams/{team}/users/{user}', static function (Request $request): Response {
+                    return Response::json($request->routeParameters());
+                });
+            });
+        });
+
+        $response = $router->dispatch(new Request('GET', '/api/v1/teams/7/users/42'));
+
+        self::assertSame(['team' => '7', 'user' => '42'], $response->payload());
+    }
+
+    public function test_router_group_name_prefix_and_explicit_route_name_create_named_route_placeholder(): void
+    {
+        $router = new Router();
+
+        $router->group('/api', static function (Router $router): void {
+            $router->group('/v1', static function (Router $router): void {
+                $router->get('/users/{user}', static fn (): Response => Response::json(['ok' => true]))->name('users.show');
+            }, name: 'v1.');
+        }, name: 'api.');
+
+        self::assertSame('api.v1.users.show', $router->routeName('GET', '/api/v1/users/42'));
+    }
+
+    public function test_router_group_name_prefix_does_not_leak_to_routes_outside_group(): void
+    {
+        $router = new Router();
+
+        $router->group('/api', static function (Router $router): void {
+            $router->get('/users/{user}', static fn (): Response => Response::json(['ok' => true]))->name('users.show');
+        }, name: 'api.');
+
+        $router->get('/health', static fn (): Response => Response::json(['ok' => true]))->name('health');
+
+        self::assertSame('api.users.show', $router->routeName('GET', '/api/users/42'));
+        self::assertSame('health', $router->routeName('GET', '/health'));
+    }
 }


### PR DESCRIPTION
## 变更摘要
- 落地 Router alpha 第二波：prefix/group 边界与 named route 占位。
- 支持嵌套 prefix 组合、group 边界不泄漏、`RouteDefinition::name()` 与 `Router::routeName()` 最小 contract。
- 补充对应单元测试，锁定 prefix/name 边界行为。

## 为什么改
- Router 第一波已完成参数路由绑定，但真实 API 路由组织仍缺 prefix/group 组合能力与最小 named route 占位。
- 这条线最值钱，因为它在不膨胀到 resource/controller/url generator 的前提下，把 Folio 从静态 path demo 推到更可用的 alpha Router 层。

## 如何验证
- 已用本机 PHP 执行：`/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit`
- 并对变更文件执行 php-cs-fixer dry-run：
  - `src/Core/Routing/Router.php`
  - `src/Core/Routing/RouteDefinition.php`
  - `tests/Unit/Routing/RouterTest.php`
- 以当前 PR 的最新 governance-exec-mvp + php-ci checks 为准。

## 风险与兼容性
- 风险：本 PR 触及 Router 定义存储与 dispatch 匹配路径，若 prefix 组合或命名索引处理不严，可能影响 404/405 判定或路由元数据一致性。
- 兼容性：当前仅冻结 prefix/group 最小边界与 named route 占位，不引入 URL generation、resource route、controller auto-dispatch 等更重能力。

关联 issue: #45
状态: in-review
风险: low