### PR TITLE
feat: add named route url generation

### DIFF
--- a/src/Core/Routing/Router.php
+++ b/src/Core/Routing/Router.php
@@ -9,6 +9,7 @@ use Folio\Core\Exceptions\MethodNotAllowedHttpException;
 use Folio\Core\Exceptions\NotFoundHttpException;
 use Folio\Core\Http\Request;
 use Folio\Core\Http\Response;
+use InvalidArgumentException;
 
 final class Router
 {
@@ -80,6 +81,24 @@ final class Router
         $matchedRoute = $this->matchRoute(strtoupper($method), $this->normalizePath($path));
 
         return $matchedRoute['name'] ?? null;
+    }
+
+    /**
+     * @param array<string, scalar|null> $parameters
+     */
+    public function urlFor(string $name, array $parameters = []): string
+    {
+        foreach ($this->routes as $methodRoutes) {
+            foreach ($methodRoutes as $route) {
+                if (($route['name'] ?? null) !== $name) {
+                    continue;
+                }
+
+                return $this->buildPath($route['path'], $route['parameters'], $parameters);
+            }
+        }
+
+        throw new InvalidArgumentException(sprintf('Route [%s] is not defined.', $name));
     }
 
     public function dispatch(Request $request): Response
@@ -217,6 +236,44 @@ final class Router
         preg_match_all('/\{([A-Za-z_][A-Za-z0-9_]*)\}/', $path, $matches);
 
         return $matches[1] ?? [];
+    }
+
+    /**
+     * @param list<string> $expectedParameters
+     * @param array<string, scalar|null> $parameters
+     */
+    private function buildPath(string $path, array $expectedParameters, array $parameters): string
+    {
+        $resolvedPath = $path;
+
+        foreach ($expectedParameters as $parameter) {
+            if (!array_key_exists($parameter, $parameters)) {
+                throw new InvalidArgumentException(sprintf('Route [%s] is missing required parameter [%s].', $path, $parameter));
+            }
+
+            $value = $parameters[$parameter];
+
+            if ($value === null || $value === '') {
+                throw new InvalidArgumentException(sprintf('Route [%s] parameter [%s] must be a non-empty scalar.', $path, $parameter));
+            }
+
+            $resolvedPath = str_replace('{'.$parameter.'}', rawurlencode((string) $value), $resolvedPath);
+            unset($parameters[$parameter]);
+        }
+
+        if ($parameters === []) {
+            return $resolvedPath;
+        }
+
+        ksort($parameters);
+
+        $query = http_build_query($parameters, '', '&', PHP_QUERY_RFC3986);
+
+        if ($query === '') {
+            return $resolvedPath;
+        }
+
+        return $resolvedPath.'?'.$query;
     }
 
     private function currentNamePrefix(): string

--- a/tests/Unit/Routing/RouterTest.php
+++ b/tests/Unit/Routing/RouterTest.php
@@ -9,6 +9,7 @@ use Folio\Core\Exceptions\NotFoundHttpException;
 use Folio\Core\Http\Request;
 use Folio\Core\Http\Response;
 use Folio\Core\Routing\Router;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 final class RouterTest extends TestCase
@@ -112,5 +113,51 @@ final class RouterTest extends TestCase
 
         self::assertSame('api.users.show', $router->routeName('GET', '/api/users/42'));
         self::assertSame('health', $router->routeName('GET', '/health'));
+    }
+
+    public function test_router_can_generate_url_from_named_route_with_parameters_and_query_string(): void
+    {
+        $router = new Router();
+
+        $router->group('/api', static function (Router $router): void {
+            $router->group('/v1', static function (Router $router): void {
+                $router->get('/users/{user}', static fn (): Response => Response::json(['ok' => true]))->name('users.show');
+            }, name: 'v1.');
+        }, name: 'api.');
+
+        self::assertSame('/api/v1/users/42?include=roles&page=2', $router->urlFor('api.v1.users.show', [
+            'user' => 42,
+            'page' => 2,
+            'include' => 'roles',
+        ]));
+    }
+
+    public function test_router_url_generation_encodes_path_parameters(): void
+    {
+        $router = new Router();
+        $router->get('/files/{path}', static fn (): Response => Response::json(['ok' => true]))->name('files.show');
+
+        self::assertSame('/files/a%20b', $router->urlFor('files.show', ['path' => 'a b']));
+    }
+
+    public function test_router_url_generation_rejects_missing_required_parameter(): void
+    {
+        $router = new Router();
+        $router->get('/users/{user}', static fn (): Response => Response::json(['ok' => true]))->name('users.show');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('missing required parameter [user]');
+
+        $router->urlFor('users.show');
+    }
+
+    public function test_router_url_generation_rejects_unknown_route_name(): void
+    {
+        $router = new Router();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Route [missing.route] is not defined.');
+
+        $router->urlFor('missing.route');
     }
 }


### PR DESCRIPTION
## 变更摘要
- 落地 Router 第三波：冻结 route metadata contract，并补上基于 named route 的最小 URL generation 闭环。
- 新增 `Router::urlFor()`，支持按 route name 生成 canonical path、路径参数替换与 RFC3986 query string。
- 补充缺参/未知路由失败路径测试，锁定当前 alpha 阶段 URL generation 行为。

## 为什么改
- Router 第一波和第二波已经把参数路由、prefix/group、named route 占位推进到 main，但“命名路由”仍然只能登记不能消费。
- 这一波的价值在于把 route metadata 从松散占位推进到可被真实 API 层消费的最小闭环，同时仍严格控制在 0.2.x-alpha 路由主线内。

## 如何验证
- 已用本机 PHP 执行：`/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit tests/Unit/Routing/RouterTest.php`
- 已用本机 PHP 执行全量测试：`/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit`
- 当前以最新 governance-exec-mvp + php-ci 检查结果为准。

## 风险与兼容性
- 风险：本 PR 触及 route metadata 存储与 name -> canonical path 解析，若 contract 边界不稳，可能影响 prefix/group 后的命名路由一致性。
- 兼容性：当前仅提供最小 URL generation 闭环，不引入 controller auto-dispatch、resource route、route cache、validation/auth/db/queue 等更重能力。

关联 issue: #47
状态: in-review
风险: low