### PR TITLE
feat: add request input and validation alpha baseline

### DIFF
--- a/src/Core/Exceptions/ValidationException.php
+++ b/src/Core/Exceptions/ValidationException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Folio\Core\Exceptions;
+
+final class ValidationException extends HttpException
+{
+    /** @param array<string, list<string>> $errors */
+    public function __construct(private readonly array $errors)
+    {
+        parent::__construct(422, 'VALIDATION_FAILED', 'The given data was invalid.');
+    }
+
+    /** @return array<string, list<string>> */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+
+    public function meta(): array
+    {
+        return ['errors' => $this->errors];
+    }
+}

--- a/src/Core/Http/Request.php
+++ b/src/Core/Http/Request.php
@@ -6,7 +6,11 @@ namespace Folio\Core\Http;
 
 final class Request
 {
-    /** @param array<string, string> $routeParameters */
+    /**
+     * @param array<string, mixed> $query
+     * @param array<string, mixed> $server
+     * @param array<string, string> $routeParameters
+     */
     public function __construct(
         private readonly string $method,
         private readonly string $path,
@@ -44,19 +48,42 @@ final class Request
         return $this->path;
     }
 
+    /** @return array<string, mixed> */
     public function query(): array
     {
         return $this->query;
     }
 
+    public function input(string $key, mixed $default = null): mixed
+    {
+        return $this->query[$key] ?? $default;
+    }
+
+    /** @return array<string, mixed> */
     public function server(): array
     {
         return $this->server;
     }
 
+    public function header(string $key, mixed $default = null): mixed
+    {
+        $normalized = 'HTTP_'.strtoupper(str_replace('-', '_', $key));
+
+        return $this->server[$normalized] ?? $this->server[strtoupper($key)] ?? $default;
+    }
+
     public function body(): mixed
     {
         return $this->body;
+    }
+
+    public function bodyInput(string $key, mixed $default = null): mixed
+    {
+        if (!is_array($this->body)) {
+            return $default;
+        }
+
+        return $this->body[$key] ?? $default;
     }
 
     /** @return array<string, string> */

--- a/src/Core/Validation/Validator.php
+++ b/src/Core/Validation/Validator.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Folio\Core\Validation;
+
+use Folio\Core\Exceptions\ValidationException;
+
+final class Validator
+{
+    /**
+     * @param array<string, mixed> $data
+     * @param array<string, list<string>> $rules
+     * @return array<string, mixed>
+     */
+    public function validate(array $data, array $rules): array
+    {
+        $errors = [];
+
+        foreach ($rules as $field => $fieldRules) {
+            $value = $data[$field] ?? null;
+            $present = array_key_exists($field, $data);
+
+            foreach ($fieldRules as $rule) {
+                if ($rule === 'required') {
+                    if (!$present || $value === null || $value === '') {
+                        $errors[$field][] = 'The field is required.';
+                    }
+
+                    continue;
+                }
+
+                if (!$present || $value === null) {
+                    continue;
+                }
+
+                if ($rule === 'string' && !is_string($value)) {
+                    $errors[$field][] = 'The field must be a string.';
+                    continue;
+                }
+
+                if ($rule === 'integer' && !is_int($value)) {
+                    $errors[$field][] = 'The field must be an integer.';
+                    continue;
+                }
+
+                if ($rule === 'array' && !is_array($value)) {
+                    $errors[$field][] = 'The field must be an array.';
+                }
+            }
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        return $data;
+    }
+}

--- a/tests/Unit/Exceptions/HandlerTest.php
+++ b/tests/Unit/Exceptions/HandlerTest.php
@@ -8,6 +8,7 @@ use Folio\Core\Config\ConfigRepository;
 use Folio\Core\Exceptions\Handler;
 use Folio\Core\Exceptions\MethodNotAllowedHttpException;
 use Folio\Core\Exceptions\NotFoundHttpException;
+use Folio\Core\Exceptions\ValidationException;
 use Folio\Core\Http\Request;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -64,5 +65,37 @@ final class HandlerTest extends TestCase
 
         self::assertArrayNotHasKey('meta', $response->payload()['error']);
         self::assertSame(['should_report' => false], $response->payload()['error']['report']);
+    }
+
+    public function test_validation_exception_uses_unified_json_error_boundary(): void
+    {
+        $handler = new Handler(new ConfigRepository(['app' => ['debug' => false]]));
+        $request = new Request('POST', '/api/v1/users', [], [], ['name' => 123]);
+
+        $response = $handler->render($request, new ValidationException([
+            'name' => ['The field must be a string.'],
+        ]));
+
+        self::assertSame(422, $response->status());
+        self::assertSame(
+            [
+                'error' => [
+                    'code' => 'VALIDATION_FAILED',
+                    'message' => 'The given data was invalid.',
+                    'meta' => [
+                        'errors' => [
+                            'name' => ['The field must be a string.'],
+                        ],
+                    ],
+                    'context' => ['method' => 'POST', 'path' => '/api/v1/users'],
+                    'report' => ['should_report' => false],
+                    'render' => [
+                        'status' => 422,
+                        'headers' => [],
+                    ],
+                ],
+            ],
+            $response->payload()
+        );
     }
 }

--- a/tests/Unit/Http/RequestTest.php
+++ b/tests/Unit/Http/RequestTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Http;
+
+use Folio\Core\Http\Request;
+use PHPUnit\Framework\TestCase;
+
+final class RequestTest extends TestCase
+{
+    public function test_request_exposes_query_body_header_and_route_inputs(): void
+    {
+        $request = new Request(
+            'POST',
+            '/api/v1/users/42',
+            ['page' => 2, 'filter' => 'active'],
+            ['HTTP_X_TRACE_ID' => 'trace-123', 'CONTENT_TYPE' => 'application/json'],
+            ['name' => '楚锦', 'age' => 18, 'tags' => ['core']],
+            ['user' => '42'],
+        );
+
+        self::assertSame(2, $request->input('page'));
+        self::assertSame('active', $request->input('filter'));
+        self::assertSame('fallback', $request->input('missing', 'fallback'));
+        self::assertSame('trace-123', $request->header('X-Trace-Id'));
+        self::assertSame('application/json', $request->header('CONTENT_TYPE'));
+        self::assertSame('楚锦', $request->bodyInput('name'));
+        self::assertSame(['core'], $request->bodyInput('tags'));
+        self::assertSame('42', $request->routeParameter('user'));
+    }
+
+    public function test_request_body_input_returns_default_when_body_is_not_array(): void
+    {
+        $request = new Request('POST', '/submit', [], [], 'raw-body');
+
+        self::assertSame('fallback', $request->bodyInput('name', 'fallback'));
+    }
+}

--- a/tests/Unit/Validation/ValidatorTest.php
+++ b/tests/Unit/Validation/ValidatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Validation;
+
+use Folio\Core\Exceptions\ValidationException;
+use Folio\Core\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+final class ValidatorTest extends TestCase
+{
+    public function test_validator_accepts_minimal_supported_rules(): void
+    {
+        $validator = new Validator();
+
+        $validated = $validator->validate([
+            'name' => '楚锦',
+            'age' => 18,
+            'tags' => ['core'],
+        ], [
+            'name' => ['required', 'string'],
+            'age' => ['required', 'integer'],
+            'tags' => ['required', 'array'],
+        ]);
+
+        self::assertSame([
+            'name' => '楚锦',
+            'age' => 18,
+            'tags' => ['core'],
+        ], $validated);
+    }
+
+    public function test_validator_throws_validation_exception_with_unified_errors(): void
+    {
+        $validator = new Validator();
+
+        try {
+            $validator->validate([
+                'name' => 123,
+                'age' => '18',
+                'tags' => 'core',
+            ], [
+                'name' => ['required', 'string'],
+                'age' => ['required', 'integer'],
+                'tags' => ['required', 'array'],
+                'email' => ['required', 'string'],
+            ]);
+
+            self::fail('Expected ValidationException was not thrown.');
+        } catch (ValidationException $exception) {
+            self::assertSame(422, $exception->status());
+            self::assertSame('VALIDATION_FAILED', $exception->errorCode());
+            self::assertSame([
+                'name' => ['The field must be a string.'],
+                'age' => ['The field must be an integer.'],
+                'tags' => ['The field must be an array.'],
+                'email' => ['The field is required.'],
+            ], $exception->meta()['errors']);
+        }
+    }
+}


### PR DESCRIPTION
## 变更摘要
- 为 `Request` 增加统一输入读取面：`input()` / `bodyInput()` / `header()`，冻结 query/body/header 的最小读取 contract。
- 新增 `ValidationException` 与最小 `Validator`，支持 `required` / `string` / `integer` / `array` 四类基础规则。
- 将 validation failure 接入现有 JSON error boundary，补齐 Request / Validation alpha 第一刀单测。

## 为什么改
- PR #48 合入后，Router 三波已经完成最小可用闭环；下一阶段主线已切到 `#49` Request / Validation。
- 当前最值钱的缺口不是继续打磨 Router DSL，而是让 API-first 场景具备最基本的输入读取与 validation 失败出口。
- 这一刀故意保持轻依赖，不引入 auth / session / db，只先把 Request / Validation alpha baseline 立住。

## 如何验证
- 已执行：`/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit tests/Unit/Http/RequestTest.php tests/Unit/Validation/ValidatorTest.php tests/Unit/Exceptions/HandlerTest.php`
- 已执行：`/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit`
- 说明：仓库当前 `composer cs:check` / `php-cs-fixer fix --dry-run --diff` 仍因缺少 fixer 配置文件而失败，这属于仓库现存问题，不是本 PR 新引入问题。

## 风险与兼容性
- 风险：本 PR 冻结了 Request 读取与 validation failure 的 alpha 口径，后续若要扩展 nested input / dot notation / rule DSL，需要继续显式演进而不是偷偷改语义。
- 兼容性：当前只提供最小读取与最小规则集，不包含 auth、session、ORM、复杂规则 DSL。

关联 issue: #49
状态: in-review
风险: medium